### PR TITLE
Fix invalid parameter typo in constants

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -150,7 +150,7 @@ coms[0x01] = "ERROR (0x01)";
 coms.INVALID_COMMAND = 0x02;
 coms[0x02] = "Invalid Command (0x02)";
 coms.INVALID_PARAMETER = 0x03;
-coms[0x03] = "Invalid Command (0x03)";
+coms[0x03] = "Invalid Parameter (0x03)";
 coms.REMOTE_CMD_TRANS_FAILURE = 0x04;
 coms[0x04] = "Remote Command Transmission Failed (0x04)";
 


### PR DESCRIPTION
I'm using the strings in my project and noticed this typo.
