### PR TITLE
Move the event handler to after the serial port is open

### DIFF
--- a/examples/basic/basic.js
+++ b/examples/basic/basic.js
@@ -25,9 +25,12 @@ serialport.on("open", function() {
     if (err) throw(err);
     else     console.log("written bytes: "+util.inspect(res));
   });
+  
+  xbeeAPI.on("frame_object", function(frame) {
+    console.log("OBJ> "+util.inspect(frame));
+  });
+  
 });
 
 
-xbeeAPI.on("frame_object", function(frame) {
-  console.log("OBJ> "+util.inspect(frame));
-});
+


### PR DESCRIPTION
This prevents a race condition where the library returns check sum mismatch errors on networks with multiple nodes.
