### PR TITLE
Adding parser for 0x83; RX_PACKET_16_IO

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -189,6 +189,9 @@ frame_parser.ParseIOSamplePayload = function(frame, buffer) {
 };
 
 // Series 1 Support
+frame_parser.Recieved16BitPacketIO = function(frame, buffer) {
+}
+
 frame_parser[C.FRAME_TYPE.TX_STATUS] = function(frame, buffer) {
   frame.id = buffer.readUInt8(0);
   frame.deliveryStatus = buffer.readUInt8(1);
@@ -216,10 +219,76 @@ frame_parser[C.FRAME_TYPE.RX_PACKET_64_IO] = function(frame, buffer) {
   // TODO: Parse I/O Data?
 };
 
+
 frame_parser[C.FRAME_TYPE.RX_PACKET_16_IO] = function(frame, buffer) {
-  frame.remote16 = frame_parser.parseAddress(buffer, 0, 2);
-  frame.rssi = buffer.readUInt8(2);
+  var hasDigital       = 0;
+  frame.remote16       = frame_parser.parseAddress(buffer, 0, 2);
+  frame.rssi           = buffer.readUInt8(2);
   frame.receiveOptions = buffer.readUInt8(3);
-  frame.data = toArray(buffer.slice(4));
-  // TODO: Parse I/O Data?
+  frame.sampleQuantity = buffer.readUInt8(4);
+  frame.channelMask    = buffer.readUInt16BE(5);
+  frame.channels       = {};
+  frame.analogSamples  = [];
+  frame.digitalSamples = [];
+  /*
+  frame.channels       = {
+    ADC5: Boolean(frame.channelMask & parseInt("0100000000000000", 2)),
+    ADC4: Boolean(frame.channelMask & parseInt("0010000000000000", 2)),
+    ADC3: Boolean(frame.channelMask & parseInt("0001000000000000", 2)),
+    ADC2: Boolean(frame.channelMask & parseInt("0000100000000000", 2)),
+    ADC1: Boolean(frame.channelMask & parseInt("0000010000000000", 2)),
+    ADC0: Boolean(frame.channelMask & parseInt("0000001000000000", 2)),
+    DIO8: Boolean(frame.channelMask & parseInt("0000000100000000", 2)),
+    DIO7: Boolean(frame.channelMask & parseInt("0000000010000000", 2)),
+    DIO6: Boolean(frame.channelMask & parseInt("0000000001000000", 2)),
+    DIO5: Boolean(frame.channelMask & parseInt("0000000000100000", 2)),
+    DIO4: Boolean(frame.channelMask & parseInt("0000000000010000", 2)),
+    DIO3: Boolean(frame.channelMask & parseInt("0000000000001000", 2)),
+    DIO2: Boolean(frame.channelMask & parseInt("0000000000000100", 2)),
+    DIO1: Boolean(frame.channelMask & parseInt("0000000000000010", 2)),
+    DIO0: Boolean(frame.channelMask & parseInt("0000000000000001", 2))
+  };*/
+
+
+  //analog channels
+  for( var a=0; a<=5; a++ ){
+    // exponent looks odd here because analog pins start at 0000001000000000
+    if( Boolean(frame.channelMask & Math.pow(2,a+9)) ){
+      frame.channels['ADC'+a] = 1;
+    }
+  }
+
+  // if any of the DIO pins are active, parse the digital samples 
+  // 0x1ff = 0000000111111111
+  if(frame.channelMask & 0x1ff){
+    hasDigital = 1;
+    for( var i=0; i < frame.sampleQuantity; i++ ){
+      frame.digitalSamples.push( buffer.readUInt16BE(7+i).toString(2) );
+    }
+
+    //digital channels
+    for( var d=0; d<=8; d++ ){
+      if( Boolean(frame.channelMask & Math.pow(2,d)) ){
+        frame.channels['DIO'+d] = 1;
+      }
+    }
+  }
+
+  var offset=0;
+  for( var i=0; i < frame.sampleQuantity; i++ ){
+    var sample = {};
+    for( var j=0; j <= 5; j++ ){
+      if( frame.channels['ADC'+j] ){
+        // starts at the 7th byte and moved down by the Digital Samples section
+        sample['ADC'+j] = buffer.readUInt16BE(7+(hasDigital*frame.sampleQuantity)+i+offset);
+        offset += 2;
+      }
+    }
+    frame.analogSamples.push(sample);
+  }
+
+  frame.data           = frame.analogSamples; // for compatibility
+  //frame.raw            = toArray(buffer).map(function(num){return num.toString(16);});
+
+
 };

--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -190,6 +190,53 @@ frame_parser.ParseIOSamplePayload = function(frame, buffer) {
 
 // Series 1 Support
 frame_parser.Recieved16BitPacketIO = function(frame, buffer) {
+  var hasDigital = 0;
+  var data = {};
+
+  data.sampleQuantity = buffer.readUInt8(4);
+  data.channelMask    = buffer.readUInt16BE(5);
+  data.channels       = {};
+  data.analogSamples  = [];
+  data.digitalSamples = [];
+
+  //analog channels
+  for( var a=0; a<=5; a++ ){
+    // exponent looks odd here because analog pins start at 0000001000000000
+    if( Boolean(data.channelMask & Math.pow(2,a+9)) ){
+      data.channels['ADC'+a] = 1;
+    }
+  }
+
+  // if any of the DIO pins are active, parse the digital samples 
+  // 0x1ff = 0000000111111111
+  if(data.channelMask & 0x1ff){
+    hasDigital = 1;
+    for( var i=0; i < data.sampleQuantity; i++ ){
+      data.digitalSamples.push( buffer.readUInt16BE(7+i).toString(2) );
+    }
+
+    //digital channels
+    for( var d=0; d<=8; d++ ){
+      if( Boolean(data.channelMask & Math.pow(2,d)) ){
+        data.channels['DIO'+d] = 1;
+      }
+    }
+  }
+
+  var offset=0;
+  for( var i=0; i < data.sampleQuantity; i++ ){
+    var sample = {};
+    for( var j=0; j <= 5; j++ ){
+      if( data.channels['ADC'+j] ){
+        // starts at the 7th byte and moved down by the Digital Samples section
+        sample['ADC'+j] = buffer.readUInt16BE(7+(hasDigital*data.sampleQuantity)+i+offset);
+        offset += 2;
+      }
+    }
+    data.analogSamples.push(sample);
+  }
+
+  frame.data = data;
 }
 
 frame_parser[C.FRAME_TYPE.TX_STATUS] = function(frame, buffer) {
@@ -221,74 +268,8 @@ frame_parser[C.FRAME_TYPE.RX_PACKET_64_IO] = function(frame, buffer) {
 
 
 frame_parser[C.FRAME_TYPE.RX_PACKET_16_IO] = function(frame, buffer) {
-  var hasDigital       = 0;
   frame.remote16       = frame_parser.parseAddress(buffer, 0, 2);
   frame.rssi           = buffer.readUInt8(2);
   frame.receiveOptions = buffer.readUInt8(3);
-  frame.sampleQuantity = buffer.readUInt8(4);
-  frame.channelMask    = buffer.readUInt16BE(5);
-  frame.channels       = {};
-  frame.analogSamples  = [];
-  frame.digitalSamples = [];
-  /*
-  frame.channels       = {
-    ADC5: Boolean(frame.channelMask & parseInt("0100000000000000", 2)),
-    ADC4: Boolean(frame.channelMask & parseInt("0010000000000000", 2)),
-    ADC3: Boolean(frame.channelMask & parseInt("0001000000000000", 2)),
-    ADC2: Boolean(frame.channelMask & parseInt("0000100000000000", 2)),
-    ADC1: Boolean(frame.channelMask & parseInt("0000010000000000", 2)),
-    ADC0: Boolean(frame.channelMask & parseInt("0000001000000000", 2)),
-    DIO8: Boolean(frame.channelMask & parseInt("0000000100000000", 2)),
-    DIO7: Boolean(frame.channelMask & parseInt("0000000010000000", 2)),
-    DIO6: Boolean(frame.channelMask & parseInt("0000000001000000", 2)),
-    DIO5: Boolean(frame.channelMask & parseInt("0000000000100000", 2)),
-    DIO4: Boolean(frame.channelMask & parseInt("0000000000010000", 2)),
-    DIO3: Boolean(frame.channelMask & parseInt("0000000000001000", 2)),
-    DIO2: Boolean(frame.channelMask & parseInt("0000000000000100", 2)),
-    DIO1: Boolean(frame.channelMask & parseInt("0000000000000010", 2)),
-    DIO0: Boolean(frame.channelMask & parseInt("0000000000000001", 2))
-  };*/
-
-
-  //analog channels
-  for( var a=0; a<=5; a++ ){
-    // exponent looks odd here because analog pins start at 0000001000000000
-    if( Boolean(frame.channelMask & Math.pow(2,a+9)) ){
-      frame.channels['ADC'+a] = 1;
-    }
-  }
-
-  // if any of the DIO pins are active, parse the digital samples 
-  // 0x1ff = 0000000111111111
-  if(frame.channelMask & 0x1ff){
-    hasDigital = 1;
-    for( var i=0; i < frame.sampleQuantity; i++ ){
-      frame.digitalSamples.push( buffer.readUInt16BE(7+i).toString(2) );
-    }
-
-    //digital channels
-    for( var d=0; d<=8; d++ ){
-      if( Boolean(frame.channelMask & Math.pow(2,d)) ){
-        frame.channels['DIO'+d] = 1;
-      }
-    }
-  }
-
-  var offset=0;
-  for( var i=0; i < frame.sampleQuantity; i++ ){
-    var sample = {};
-    for( var j=0; j <= 5; j++ ){
-      if( frame.channels['ADC'+j] ){
-        // starts at the 7th byte and moved down by the Digital Samples section
-        sample['ADC'+j] = buffer.readUInt16BE(7+(hasDigital*frame.sampleQuantity)+i+offset);
-        offset += 2;
-      }
-    }
-    frame.analogSamples.push(sample);
-  }
-
-  frame.data           = frame.analogSamples; // for compatibility
-  //frame.raw            = toArray(buffer).map(function(num){return num.toString(16);});
-
-
+  frame_parser.Recieved16BitPacketIO(frame, buffer);
 };

--- a/lib/xbee-api.js
+++ b/lib/xbee-api.js
@@ -166,7 +166,7 @@ XBeeAPI.prototype.parseRaw = function(buffer) {
       continue;
     }
 
-    if (S.offset > 3) {
+    if (S.offset > 3) { // unnessary check
       if (S.offset < S.length+4) {
         S.total += S.b;
         continue;

--- a/test/xbee-api_test.js
+++ b/test/xbee-api_test.js
@@ -202,9 +202,8 @@ exports['API Frame Parsing'] = {
     var parser = xbeeAPI.rawParser();
     xbeeAPI.once("frame_object", function(frame) {
       test.equal(frame.remote16, '1234', "Parse remote16");
-      test.equal(frame.analogSamples.length, frame.sampleQuantity, "Parse the right number of samples");
-      test.equal(frame.channelMask, 0x0E58, "channel mask");
-      console.log(frame);
+      test.equal(frame.data.analogSamples.length, frame.data.sampleQuantity, "Parse the right number of samples");
+      test.equal(frame.data.channelMask, 0x0E58, "channel mask");
       test.done();
     });
     // Receive Packet; 0x83; Receive packet from IC or IR setting

--- a/test/xbee-api_test.js
+++ b/test/xbee-api_test.js
@@ -179,6 +179,7 @@ exports['API Frame Parsing'] = {
     var rawFrame = new Buffer([ 0x7E, 0x00, 0x02, 0x8A, 0x06, 0x6F ]);
     parser(null, rawFrame);
   }, 
+
   'Receive Packet': function(test) {
     test.expect(4);
     var xbeeAPI = new xbee_api.XBeeAPI();
@@ -194,6 +195,23 @@ exports['API Frame Parsing'] = {
     var rawFrame = new Buffer([ 0x7E, 0x00, 0x12, 0x90, 0x00, 0x13, 0xA2, 0x00, 0x40, 0x52, 0x2B, 0xAA, 0x7D, 0x84, 0x01, 0x52, 0x78, 0x44, 0x61, 0x74, 0x61, 0x0D ]);
     parser(null, rawFrame);
   }, 
+
+  'Receive Packet 16-bit IO': function(test) {
+    test.expect(3);
+    var xbeeAPI = new xbee_api.XBeeAPI({api_mode:1});
+    var parser = xbeeAPI.rawParser();
+    xbeeAPI.once("frame_object", function(frame) {
+      test.equal(frame.remote16, '1234', "Parse remote16");
+      test.equal(frame.analogSamples.length, frame.sampleQuantity, "Parse the right number of samples");
+      test.equal(frame.channelMask, 0x0E58, "channel mask");
+      console.log(frame);
+      test.done();
+    });
+    // Receive Packet; 0x83; Receive packet from IC or IR setting
+    var rawFrame = new Buffer([0x7E, 0x00, 0x10, 0x83, 0x12, 0x34, 0x1B, 0x00, 0x01, 0x0E, 0x58, 0x00, 0x18, 0x00, 0x46, 0x01, 0x54, 0x02, 0x0A, 0xF5 ]);
+    parser(null, rawFrame);
+  }, 
+
   'Route Record': function(test) {
     test.expect(5);
     var xbeeAPI = new xbee_api.XBeeAPI();
@@ -210,6 +228,7 @@ exports['API Frame Parsing'] = {
     var rawFrame = new Buffer([ 0x7e, 0x00, 0x13, 0xa1, 0x00, 0x13, 0xa2, 0x00, 0x40, 0x68, 0xf6, 0x5b, 0x6d, 0x32, 0x00, 0x03, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xbf ]);
     parser(null, rawFrame);
   },
+  
   'ZigBee IO Data Sample Rx': function(test) {
     test.expect(6);
     var xbeeAPI = new xbee_api.XBeeAPI();


### PR DESCRIPTION
This fills in a TODO for parsing the RX_PACKET_16_IO packets from Series 1 devices. The test sample comes from [the Digi documentation](http://www.digi.com/support/kbase/kbaseresultdetl?id=3522) and I can verify that it works with my Series 1 radios.