### PR TITLE
Parse IO sample when included in the response to an IS command

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -95,7 +95,12 @@ frame_parser[C.FRAME_TYPE.REMOTE_COMMAND_RESPONSE] = function(frame, reader) {
   frame.remote16 = reader.nextString(2, 'hex');
   frame.command = reader.nextString(2, 'ascii');
   frame.commandStatus = reader.nextUInt8();
-  frame.commandData = reader.nextAll();
+  if(frame.command === "IS") {
+    frame_parser.ParseIOSamplePayload(frame, reader);
+  }
+  else {
+    frame.commandData = reader.nextAll();
+  }
 };
 
 frame_parser[C.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS] = function(frame, reader) {


### PR DESCRIPTION
The reply to an IS (Force sample) command is an IO sample (like the one included in the
0x92 ZIGBEE_IO_DATA_SAMPLE_RX frame).  So, use the existing ParseIOSamplePayload
function to parse it.