### PR TITLE
ZigBee Explicit Rx (AO=1) Bad `frame.data` Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,10 +318,10 @@ This frame contains general data (such as text data) received from remote nodes.
 	type: 0x90, // xbee_api.constants.FRAME_TYPE.ZIGBEE_EXPLICIT_RX
 	remote64: "0013a20040522baa",
 	remote16: "7d84",
-        sourceEndpoint: "e8",
-        destinationEndpoint: "e8",
-        clusterId: "0011",
-        profileId: "c105",
+	sourceEndpoint: "e8",
+	destinationEndpoint: "e8",
+	clusterId: "0011",
+	profileId: "c105",
 	receiveOptions: 0x01,
 	data: [ 0x52, 0x78, 0x44, 0x61, 0x74, 0x61 ]
 }

--- a/README.md
+++ b/README.md
@@ -313,7 +313,19 @@ These statuses give information about the general operation of the XBee. See the
 This frame contains general data (such as text data) received from remote nodes.
 
 #### 0x91: ZigBee Explicit Rx Indicator (AO=1) (ZNet, ZigBee)
-See *0x90: ZigBee Receive Packet (AO=0) (ZNet, ZigBee)* above.
+```javascript
+{
+	type: 0x90, // xbee_api.constants.FRAME_TYPE.ZIGBEE_EXPLICIT_RX
+	remote64: "0013a20040522baa",
+	remote16: "7d84",
+        sourceEndpoint: "e8",
+        destinationEndpoint: "e8",
+        clusterId: "0011",
+        profileId: "c105",
+	receiveOptions: 0x01,
+	data: [ 0x52, 0x78, 0x44, 0x61, 0x74, 0x61 ]
+}
+```
 
 #### 0x92: ZigBee IO Data Sample Rx Indicator (ZNet, ZigBee)
 ```javascript

--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -19,10 +19,20 @@ frame_parser[C.FRAME_TYPE.NODE_IDENTIFICATION] = function(frame, reader) {
   frame_parser.parseNodeIdentificationPayload(frame, reader);
 };
 
-frame_parser[C.FRAME_TYPE.ZIGBEE_RECEIVE_PACKET] =
+frame_parser[C.FRAME_TYPE.ZIGBEE_RECEIVE_PACKET] = function(frame, reader) {
+  frame.remote64 = reader.nextString(8, 'hex');
+  frame.remote16 = reader.nextString(2, 'hex');
+  frame.receiveOptions = reader.nextUInt8();
+  frame.data = reader.nextAll();
+};
+
 frame_parser[C.FRAME_TYPE.ZIGBEE_EXPLICIT_RX] = function(frame, reader) {
   frame.remote64 = reader.nextString(8, 'hex');
   frame.remote16 = reader.nextString(2, 'hex');
+  frame.sourceEndpoint = reader.nextString(1, 'hex');
+  frame.destinationEndpoint = reader.nextString(1, 'hex');
+  frame.clusterId = reader.nextString(2, 'hex');
+  frame.profileId = reader.nextString(2, 'hex');
   frame.receiveOptions = reader.nextUInt8();
   frame.data = reader.nextAll();
 };

--- a/test/xbee-api_test.js
+++ b/test/xbee-api_test.js
@@ -247,6 +247,26 @@ exports['API Frame Parsing'] = {
     parser(null, rawFrame);
   }, 
 
+  'Receive Packet with AO=1': function(test) {
+    test.expect(8);
+    var xbeeAPI = new xbee_api.XBeeAPI();
+    var parser = xbeeAPI.rawParser();
+    xbeeAPI.once("frame_object", function(frame) {
+      test.equal(frame.remote64, '0013a20040c401a9', "Parse remote64");
+      test.equal(frame.remote16, '0000', "Parse remote16");
+      test.equal(frame.sourceEndpoint, 'e8', 'Source Endpoint');
+      test.equal(frame.destinationEndpoint, 'e8', 'Destination Endpoint');
+      test.equal(frame.clusterId, '0011', 'Cluster Id');
+      test.equal(frame.profileId, 'c105', 'Profile Id');
+      test.equal(frame.receiveOptions, 1, "Parse receive options");
+      test.deepEqual(frame.data, new Buffer([0x74, 0x65, 0x73, 0x74, 0x20, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65]));
+      test.done();
+    });
+    // Receive Packet; 0x90; Receive packet with chars RxData
+    var rawFrame = new Buffer([0x7E, 0x00, 0x1E, 0x91, 0x00, 0x13, 0xA2, 0x00, 0x40, 0xC4, 0x01, 0xA9, 0x00, 0x00, 0xE8, 0xE8, 0x00, 0x11, 0xC1, 0x05, 0x01, 0x74, 0x65, 0x73, 0x74, 0x20, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x9E]);
+    parser(null, rawFrame);
+  }, 
+
   'Receive Packet 16-bit IO': function(test) {
     test.expect(3);
     var xbeeAPI = new xbee_api.XBeeAPI({api_mode:1});


### PR DESCRIPTION
I found that with AO=1 I was getting garbage at the start of my data field on the Rx end of things. This was cause by a few missing fields while parsing. Using a frame generated in XCTU, I added those fields to the parse method, added a test for that frame type, and updated the README.md.