### PR TITLE
fix for out of original buffer boundary error caused by the encyption mo...

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -219,8 +219,9 @@ frame_parser.ParseIOSamplePayload = function(frame, reader) {
 frame_parser.Recieved16BitPacketIO = function(frame, reader) {
   var hasDigital = 0;
   var data = {};
-  // OFFSET 4
- //reader.move(4);
+  // OFFSET 3 if the Encryption mode is ON for 16Bit packet IO
+  if (reader.nextUint8() === 255)
+    reader.move(3);
   data.sampleQuantity = reader.nextUInt8();
   data.channelMask    = reader.nextUInt16BE(); 
   data.channels       = {};

--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -220,7 +220,7 @@ frame_parser.Recieved16BitPacketIO = function(frame, reader) {
   var hasDigital = 0;
   var data = {};
   // OFFSET 3 if the Encryption mode is ON for 16Bit packet IO
-  if (reader.nextUint8() === 255)
+  if (reader.nextUInt8() === 255)
     reader.move(3);
   data.sampleQuantity = reader.nextUInt8();
   data.channelMask    = reader.nextUInt16BE(); 


### PR DESCRIPTION
This is a temporary fix for the Encryption mode error on series 1 XBee.