### PR TITLE
Do not parse ATIS responses if lines are not enabled

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -203,6 +203,9 @@ frame_parser.parseNodeIdentificationPayload = function(frame, reader) {
 frame_parser.ParseIOSamplePayload = function(frame, reader) {
   frame.digitalSamples = {};
   frame.analogSamples = {};
+  frame.numSamples = 0;
+  // When parsing responses to ATIS, there is no data to parse if IO lines are not enabled
+  if (frame.commandStatus !== undefined && frame.commandStatus !== 0) return;
   frame.numSamples = reader.nextUInt8();
   var mskD = reader.nextUInt16BE(); 
   var mskA = reader.nextUInt8();


### PR DESCRIPTION
See Issue #37. When using the ParseIOSamplePayload function to parse Payload to on packages from nodes with disabled IO lines it will break. Checking the commandStatus of the AT response fixes this.