### PR TITLE
fix frame_parser for ATND command response

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -91,7 +91,7 @@ frame_parser[C.FRAME_TYPE.AT_COMMAND_RESPONSE] = function(frame, reader) {
   frame.id = reader.nextUInt8();
   frame.command = reader.nextString(2, 'ascii');
   frame.commandStatus = reader.nextUInt8();
-  if (frame.command === "ND") {
+  if ((frame.command === "ND") && (frame.commandStatus == C.COMMAND_STATUS.OK)) {
     frame.nodeIdentification = {};
     frame_parser.parseNodeIdentificationPayload(frame.nodeIdentification, reader);
   } else {
@@ -107,7 +107,7 @@ frame_parser[C.FRAME_TYPE.REMOTE_COMMAND_RESPONSE] = function(frame, reader) {
   frame.commandStatus = reader.nextUInt8();
   if(frame.command === "IS") {
     frame_parser.ParseIOSamplePayload(frame, reader);
-  } else if (frame.command === "ND") {
+  } else if ((frame.command === "ND") && (frame.commandStatus == C.COMMAND_STATUS.OK)) {
     frame.nodeIdentification = {};
     frame_parser.parseNodeIdentificationPayload(frame.nodeIdentification, reader);
   } else {


### PR DESCRIPTION
prevent call to parseNodeIndentificationPayload if ATND command (local or remote) response is not succesful
