### PR TITLE
Fix ND frame command

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -91,7 +91,7 @@ frame_parser[C.FRAME_TYPE.AT_COMMAND_RESPONSE] = function(frame, reader) {
   frame.id = reader.nextUInt8();
   frame.command = reader.nextString(2, 'ascii');
   frame.commandStatus = reader.nextUInt8();
-  if ((frame.command === "ND") && (frame.commandStatus == C.COMMAND_STATUS.OK)) {
+  if ((frame.command === "ND") && (frame.commandStatus == C.COMMAND_STATUS.OK) && (reader.buf.length > reader.tell())) {
     frame.nodeIdentification = {};
     frame_parser.parseNodeIdentificationPayload(frame.nodeIdentification, reader);
   } else {

--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -193,11 +193,13 @@ frame_parser.parseNodeIdentificationPayload = function(frame, reader) {
   // Extract the NI string from the buffer
   frame.nodeIdentifier = reader.nextStringZero('ascii');
 
-  frame.remoteParent16 = reader.nextString(2, 'hex');
-  frame.deviceType = reader.nextUInt8();
-  frame.sourceEvent = reader.nextUInt8();
-  frame.digiProfileID = reader.nextString(2, 'hex');
-  frame.digiManufacturerID = reader.nextString(2, 'hex');
+  if(reader.buf.length > reader.tell()) {
+    frame.remoteParent16 = reader.nextString(2, 'hex');
+    frame.deviceType = reader.nextUInt8();
+    frame.sourceEvent = reader.nextUInt8();
+    frame.digiProfileID = reader.nextString(2, 'hex');
+    frame.digiManufacturerID = reader.nextString(2, 'hex');
+  }
 };
 
 frame_parser.ParseIOSamplePayload = function(frame, reader) {

--- a/test/xbee-api_test.js
+++ b/test/xbee-api_test.js
@@ -186,7 +186,7 @@ exports['API Frame Parsing'] = {
     var rawFrame = new Buffer([ 0x7E, 0x00, 0x13, 0x97, 0x55, 0x00, 0x13, 0xA2, 0x00, 0x40, 0x52, 0x2B, 0xAA, 0x7D, 0x84, 0x53, 0x4C, 0x00, 0x40, 0x52, 0x2B, 0xAA, 0xF0 ]);
     parser(null, rawFrame);
   },
-  'AT Command Responses': function(test) {
+  'AT Command Responses, BD AT Command': function(test) {
     test.expect(3);
     var xbeeAPI = new xbee_api.XBeeAPI();
     var parser = xbeeAPI.rawParser();
@@ -200,6 +200,23 @@ exports['API Frame Parsing'] = {
 
     // AT Command Response; 0x88; ATBD [OK] (no data)
     var rawFrame = new Buffer([ 0x7E, 0x00, 0x05, 0x88, 0x01, 0x42, 0x44, 0x00, 0xF0 ]);
+    parser(null, rawFrame);
+  },
+  'AT Command Responses, ND AT Command with no data': function(test) {
+    test.expect(4);
+    var xbeeAPI = new xbee_api.XBeeAPI();
+    var parser = xbeeAPI.rawParser();
+
+    xbeeAPI.once("frame_object", function(frame) { // frame0
+      test.equal(frame.id, 0x01, "Parse frameid");
+      test.equal(frame.command, "ND", "Parse command");
+      test.equal(frame.commandStatus, 0, "Parse command status");
+      test.deepEqual(frame.commandData, new Buffer([]));
+      test.done();
+    });
+
+    // AT Command Response; 0x88; ATND [OK] (no data)
+    var rawFrame = new Buffer([ 0x7E, 0x00, 0x05, 0x88, 0x01, 0x4E, 0x44, 0x00, 0xE4 ]);
     parser(null, rawFrame);
   },
   'Transmit Status': function(test) {

--- a/test/xbee-api_test.js
+++ b/test/xbee-api_test.js
@@ -219,6 +219,25 @@ exports['API Frame Parsing'] = {
     var rawFrame = new Buffer([ 0x7E, 0x00, 0x05, 0x88, 0x01, 0x4E, 0x44, 0x00, 0xE4 ]);
     parser(null, rawFrame);
   },
+  'AT Command Responses, ND AT Command with data': function(test) {
+    test.expect(6);
+    var xbeeAPI = new xbee_api.XBeeAPI({api_mode: 2});
+    var parser = xbeeAPI.rawParser();
+
+    xbeeAPI.once("frame_object", function(frame) { // frame0
+      test.equal(frame.id, 0x01, "Parse frameid");
+      test.equal(frame.command, "ND", "Parse command");
+      test.equal(frame.commandStatus, 0, "Parse command status");
+      test.equal(frame.nodeIdentification.remote16, 'fffe');
+      test.equal(frame.nodeIdentification.remote64, '0013a20040d814a8');
+      test.equal(frame.nodeIdentification.nodeIdentifier, '4d');
+      test.done();
+    });
+
+    // AT Command Response; 0x88; ATND [OK] (with data)
+    var rawFrame = new Buffer([ 0x7E, 0x00, 0x12, 0x88, 0x01, 0x4E, 0x44, 0x00, 0xFF, 0xFE, 0x00, 0x7D, 0x33, 0xA2, 0x00, 0x40, 0xD8, 0x14, 0xA8, 0x34, 0x64, 0x00, 0xC6 ]);
+    parser(null, rawFrame);
+  },
   'Transmit Status': function(test) {
     test.expect(5);
     var xbeeAPI = new xbee_api.XBeeAPI();


### PR DESCRIPTION
I tested it on 2 XBee with 802.15.4 function and found the below bug: 

In a coordinator & end point network, when a coordinator sends out a AT Command (0x08) frame with ND Command, all connected end point, including itself will respond. When the coordinator respond to it's own frame, it will not include remote16 or remote64 as data. The code will throw a Buffer Boundary as it expects all responding packet to include remote data.

XBee with 802.15.4 function set (end point) will not respond with information such as remoteParent16, deviceType, etc. Hence, I wrap a check to prevent Buffer Boundary error.