### PR TITLE
frame_id exceeds the limit (0xff)

### DIFF
--- a/lib/frame-builder.js
+++ b/lib/frame-builder.js
@@ -14,7 +14,7 @@ var assert = require('assert'),
 var frame_builder = module.exports = {
   frameId: 0,
   nextFrameId: function nextFrameId() {
-    this.frameId = this.frameId > 0xff ? 1 : ++this.frameId;
+    this.frameId = this.frameId >= 0xff ? 1 : ++this.frameId;
     return this.frameId;
   },
 


### PR DESCRIPTION
If the frame_id is 0xff next frame id should be 1.