### PR TITLE
commandParameter value passed to buildFrame support Buffer

### DIFF
--- a/lib/frame-builder.js
+++ b/lib/frame-builder.js
@@ -28,7 +28,7 @@ var frame_builder = module.exports = {
 
 // Appends data provided as Array, String, or Buffer
 function appendData(data, builder) {
-  if(Array.isArray(data)) {
+  if(Array.isArray(data) || Buffer.isBuffer(data)) {
     data = new Buffer(data);
   } else {
     data = new Buffer(data, 'ascii');


### PR DESCRIPTION
It's easier to assign value to commandParameter by using a buffer than building my own array.
Comment in code of appendData() says the function also accept buffer but it doesn't work actually.
May be it's my version of node (actually i'm using last stable of nw.js, not node)
  ```
var sleeptime = 400;
var b = Buffer.alloc(4);  
b.writeUInt32BE(sleeptime);  
frame.commandParameter = b;

Array.isArray(b); // false
```


Also, since new Buffer() constructor is deprecated shouldn't we migrate to Buffer.from() ?


