### PR TITLE
Support old versions of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 6.0
+  - 0.10
+  - 0.12
+  - 4
+  - 6
 before_script:
   - npm install -g grunt-cli
 notifications:

--- a/lib/frame-builder.js
+++ b/lib/frame-builder.js
@@ -9,7 +9,8 @@
 'use strict';
 
 var assert = require('assert'),
-    C = require('./constants');
+    C = require('./constants'),
+    Buffer = require('safe-buffer').Buffer;
 
 var frame_builder = module.exports = {
   frameId: 0,

--- a/lib/xbee-api.js
+++ b/lib/xbee-api.js
@@ -11,6 +11,7 @@
 var util = require('util'),
     assert = require('assert'),
     events = require('events'),
+    Buffer = require('safe-buffer').Buffer,
     BufferBuilder = require('buffer-builder'),
     BufferReader = require('buffer-reader');
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "licenses": "MIT",
   "main": "lib/xbee-api",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "grunt nodeunit"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "keywords": [],
   "dependencies": {
     "buffer-builder": "^0.2.0",
-    "buffer-reader": "https://github.com/prodatakey/node-buffer-reader/archive/v0.0.3.tar.gz"
+    "buffer-reader": "https://github.com/prodatakey/node-buffer-reader/archive/v0.0.3.tar.gz",
+    "safe-buffer": "~5.0.1"
   }
 }


### PR DESCRIPTION
This updates the library to use `safe-buffer` which is a tiny library that mocks the new Buffer APIs found in v5.x and beyond for use in older versions of Node.js.

@jankolkmeier I didn't update any of the examples or tests, just the library itself.  Let me know if you'd like me to change that.

Closes #53 
