### PR TITLE
Provide StreamTransformer interface for serialport 5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
   - 4
   - 6
+  - 7
+  - 8
+  - node
 before_script:
   - npm install -g grunt-cli
 notifications:

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -1,0 +1,101 @@
+/*jslint node: true */
+
+'use strict';
+
+var util = require('util');
+var Transform = require('stream').Transform;
+var C = require('./constants.js');
+
+function StreamTransformer(options) {
+  if (!(this instanceof StreamTransformer)) {
+    return new StreamTransformer(options);
+  }
+
+  this.parseState = options.parseState;
+  this.options = options.options;
+  this.canParse = options.canParse;
+  this.parseFrame = options.parseFrame;
+
+  Transform.call(this, options);
+}
+util.inherits(StreamTransformer, Transform);
+
+StreamTransformer.prototype._transform = function (chunk, enc, cb) {
+  var S = this.parseState;
+  for(var i = 0; i < chunk.length; i++) {
+    S.b = chunk[i];
+    if ((S.waiting || (this.options.api_mode === 2 && !S.escape_next)) && S.b === C.START_BYTE) {
+      S.buffer = Buffer.alloc(this.options.parser_buffer_size);
+      S.length = 0;
+      S.total = 0;
+      S.checksum = 0x00;
+      S.offset = 0;
+      S.escape_next = false;
+      S.waiting = false;
+    }
+
+    if (this.options.api_mode === 2 && S.b === C.ESCAPE) {
+      S.escape_next = true;
+      continue;
+    }
+
+    if (S.escape_next) {
+      S.b = 0x20 ^ S.b;
+      S.escape_next = false;
+    }
+
+    if (!S.waiting) {
+      if (S.buffer.length > S.offset) {
+        S.buffer.writeUInt8(S.b, S.offset++);
+      } else {
+        console.warn("Packet being parsed doesn't fit allocated buffer.\n"+
+          "Consider increasing parser_buffer_size option.");
+        S.waiting = true;
+      }
+    }
+
+    if (S.offset === 1) {
+      continue;
+    }
+
+    if (S.offset === 2) {
+      S.length  = S.b << 8; // most sign. bit of the length
+      continue;
+    }
+    if (S.offset === 3) {
+      S.length += S.b;     // least sign. bit of the length
+      continue;
+    }
+
+    if (S.offset > 3) { // unnessary check
+      if (S.offset < S.length+4) {
+        S.total += S.b;
+        continue;
+      } else {
+        S.checksum = S.b;
+      }
+    }
+
+    if (S.length > 0 && S.offset === S.length + 4) {
+      if (S.checksum !== (255 - (S.total % 256))) {
+        var err = new Error("Checksum Mismatch " + JSON.stringify(S));
+        this.emit('error', err);
+      }
+
+      var rawFrame = S.buffer.slice(0, S.offset);
+      if (this.options.raw_frames || !this.canParse(rawFrame)) {
+        this.push(rawFrame);
+      } else {
+        var frame = this.parseFrame(rawFrame);
+        this.emit("frame_object", frame);
+        this.push(rawFrame);
+      }
+      // Reset some things so we don't try to re-emit the same package if there is more (bogus?) data
+      S.waiting = true;
+      S.length = 0;
+    }
+  }
+  cb();
+};
+
+module.exports = StreamTransformer;

--- a/lib/xbee-api.js
+++ b/lib/xbee-api.js
@@ -20,6 +20,7 @@ exports = module.exports;
 var C       = exports.constants = require('./constants.js');
 var frame_parser = exports._frame_parser = require('./frame-parser');
 var frame_builder = exports._frame_builder = require('./frame-builder');
+var stream_transformer = require('./transformer');
 
 var _options = {
   raw_frames: false,
@@ -133,10 +134,14 @@ XBeeAPI.prototype.nextFrameId = function() {
   return frame_builder.nextFrameId();
 };
 
-XBeeAPI.prototype.rawParser = function() {
+XBeeAPI.prototype.rawParser = function() { // Custom parsers are supported up to Node Serialport 4.0.7
   return function(emitter, buffer) {
     this.parseRaw(buffer);
   }.bind(this);
+};
+
+XBeeAPI.prototype.newStream = function () { // Transform stream for Node Serialport 5.0.0+
+  return new stream_transformer(this);
 };
 
 XBeeAPI.prototype.parseRaw = function(buffer) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "grunt nodeunit"
   },
   "devDependencies": {
-    "serialport": "~4.0.0",
+    "serialport": "~6.0.4",
     "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-nodeunit": "~1.0.0",
     "grunt-contrib-watch": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "bugs": {
     "url": "https://github.com/jankolkmeier/xbee-api/issues"
   },
-  "licenses": "MIT",
+  "license": "MIT",
   "main": "lib/xbee-api",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0.0"
   },
   "scripts": {
     "test": "grunt nodeunit"


### PR DESCRIPTION
Hi!

Serialport is already at v6, I thought to get us somewhere by providing alternative frame parsing mechanism via Transform interface. Or at least start us discussing how to provide a solution for using higher version serialport. Preserves backwards compatibility with serialport 4 and also keeps the `frame_object` event for smooth transition. Addresses #62.

Drops end-of-life node versions, min node engine >=4, added new node versions to travis. devDep serialport to version 6.

Feedback welcome, To use/test the new parser, here's an example:

```javascript
var util = require('util');
var SerialPort = require('serialport');
var xbee_api = require('./lib/xbee-api');

var C = xbee_api.constants;

var xbeeAPI = new xbee_api.XBeeAPI({
  api_mode: 2
});

var parser = xbeeAPI.newStream();

var serialport = new SerialPort("/dev/cu.usbserial-00203114", {
  baudRate: 9600
});

serialport.pipe(parser);

serialport.on("open", function() {
  console.log("port opened");
  var frame_obj = { // AT Request to be sent to 
    type: C.FRAME_TYPE.AT_COMMAND,
    command: "NI",
    commandParameter: []
  };

  serialport.write(xbeeAPI.buildFrame(frame_obj));
});

parser.on('data', function(data) {
  console.log("Stream Transformer:");
  console.log(data);
});

parser.on("frame_object", function(frame) {
  console.log("Frame object:");
  console.log(">>", frame);

  var frame_obj = { // AT Request to be sent to
    type: C.FRAME_TYPE.AT_COMMAND,
    command: "NI",
    commandParameter: []
  };

  serialport.write(xbeeAPI.buildFrame(frame_obj));
});
```
Cheers! 🍻 